### PR TITLE
Stateful samplers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -341,7 +341,10 @@ impl DeepRenderApp {
 
         ui.checkbox(&mut self.print_weights, "Print weights (uncheck for speed)");
 
-        ui.label(format!("Loss: {}", self.model.loss(self.sampler.full())));
+        ui.label(format!(
+            "Loss: {}",
+            self.loss_history.last().copied().unwrap_or(0.)
+        ));
 
         if self.print_weights {
             ui.label(format!("Model:\n{}", self.model));

--- a/src/app.rs
+++ b/src/app.rs
@@ -330,7 +330,7 @@ impl DeepRenderApp {
                 ui.label("Trains per frame:");
                 ui.add(egui::widgets::Slider::new(
                     &mut self.trains_per_frame,
-                    1..=150,
+                    1..=1000,
                 ));
             });
         });
@@ -432,8 +432,8 @@ impl DeepRenderApp {
                     self.img_predict.paint(
                         &response,
                         &painter,
-                        (self.sampler.full(), &self.model),
-                        |(train, model): (&Matrix, &Model)| {
+                        &self.model,
+                        |model: &Model| {
                             let image = (0..angle_stride * self.upsample * self.upsample)
                                 .map(|i| {
                                     let x =

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,6 @@ use eframe::{
     },
     epaint::{pos2, Color32, Pos2, Rect},
 };
-use rand::seq::SliceRandom;
 
 use crate::{
     activation::ActivationFn,
@@ -16,14 +15,8 @@ use crate::{
     matrix::Matrix,
     model::Model,
     optimizer::OptimizerType,
+    sampler::{Sampler, TrainBatch},
 };
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum TrainBatch {
-    Sequence,
-    Shuffle,
-    Full,
-}
 
 pub struct DeepRenderApp {
     fit_model: FitModel,
@@ -31,7 +24,7 @@ pub struct DeepRenderApp {
     file_name: String,
     /// Image size used in synthesized images. FileImage should read size from file.
     synth_image_size: i32,
-    train: Matrix,
+    sampler: Box<dyn Sampler>,
     train_batch: TrainBatch,
     batch_size: usize,
     image_size: Option<ImageSize>,
@@ -59,9 +52,9 @@ impl DeepRenderApp {
     pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
         let fit_model = FitModel::Xor;
         let file_name = "alan.jpg".to_string();
-        let (train, image_size) = fit_model.train_data(&file_name, IMAGE_HALFWIDTH).unwrap();
+        let (sampler, image_size) = fit_model.train_data(&file_name, IMAGE_HALFWIDTH).unwrap();
         let hidden_layers = 1;
-        let mut arch = vec![train.cols() - 1];
+        let mut arch = vec![fit_model.num_inputs()];
         for _ in 0..hidden_layers {
             arch.push(2);
         }
@@ -74,7 +67,7 @@ impl DeepRenderApp {
             current_fit_model: fit_model,
             file_name,
             synth_image_size: IMAGE_HALFWIDTH,
-            train,
+            sampler,
             train_batch: TrainBatch::Sequence,
             batch_size: 1,
             image_size,
@@ -99,11 +92,11 @@ impl DeepRenderApp {
 
     fn reset(&mut self) {
         self.current_fit_model = self.fit_model;
-        (self.train, self.image_size) = self
+        (self.sampler, self.image_size) = self
             .fit_model
             .train_data(&self.file_name, self.synth_image_size)
             .unwrap();
-        let mut arch = vec![self.train.cols() - 1];
+        let mut arch = vec![self.fit_model.num_inputs()];
         for _ in 0..self.hidden_layers {
             arch.push(self.hidden_nodes);
         }
@@ -116,34 +109,9 @@ impl DeepRenderApp {
 
     fn learn_iter(&mut self) {
         let rate = (10.0f64).powf(self.rate);
-        match self.train_batch {
-            TrainBatch::Sequence => {
-                let batches = (self.train.rows() + self.batch_size - 1) / self.batch_size;
-                for i in 0..batches {
-                    let train = self.train.row_range(
-                        i * self.batch_size,
-                        ((i + 1) * self.batch_size).min(self.train.rows()),
-                    );
-                    self.model.learn(rate, &train);
-                }
-            }
-            TrainBatch::Shuffle => {
-                let batches = (self.train.rows() + self.batch_size - 1) / self.batch_size;
-                let mut order: Vec<_> = (0..self.train.rows()).collect();
-                order.shuffle(&mut rand::thread_rng());
-                for i in 0..batches {
-                    let start = i * self.batch_size;
-                    let end = ((i + 1) * self.batch_size).min(self.train.rows());
-                    let mut train = Matrix::zeros(end - start, self.train.cols());
-                    for j in start..end {
-                        train.row_mut(j - start).copy_from_slice(self.train.row(j));
-                    }
-                    self.model.learn(rate, &train);
-                }
-            }
-            TrainBatch::Full => self.model.learn(rate, &self.train),
-        }
-        self.loss_history.push(self.model.loss(&self.train));
+        let samples = self.sampler.sample(self.train_batch, self.batch_size);
+        self.model.learn(rate, &samples);
+        self.loss_history.push(self.model.loss(self.sampler.full()));
         self.add_weights_history();
     }
 
@@ -324,7 +292,7 @@ impl DeepRenderApp {
             ui.horizontal(|ui| {
                 ui.label("Batch size:");
                 // There is no real point having more than 50 batches.
-                let max_batches = self.train.rows().min(50);
+                let max_batches = 50;
                 ui.add_enabled(
                     !matches!(self.train_batch, TrainBatch::Full),
                     egui::Slider::new(&mut self.batch_size, 1..=max_batches),
@@ -360,11 +328,11 @@ impl DeepRenderApp {
 
         ui.checkbox(&mut self.print_weights, "Print weights (uncheck for speed)");
 
-        ui.label(format!("Loss: {}", self.model.loss(&self.train)));
+        ui.label(format!("Loss: {}", self.model.loss(self.sampler.full())));
 
         if self.print_weights {
             ui.label(format!("Model:\n{}", self.model));
-            for sample in self.train.iter_rows() {
+            for sample in self.sampler.full().iter_rows() {
                 let predict = self.model.predict(sample);
                 ui.label(format!("{} -> {}", Matrix::new_row(&sample[0..2]), predict));
             }
@@ -374,8 +342,8 @@ impl DeepRenderApp {
     fn func_plot(&self, ui: &mut Ui) {
         let plot = Plot::new("plot");
         plot.legend(Legend::default()).show(ui, |plot_ui| {
-            let points: PlotPoints = self
-                .train
+            let train = self.sampler.full();
+            let points: PlotPoints = train
                 .iter_rows()
                 .map(|sample| [sample[0], sample[1]])
                 .collect();
@@ -383,8 +351,7 @@ impl DeepRenderApp {
                 .color(eframe::egui::Color32::from_rgb(0, 0, 255))
                 .name("Training");
             plot_ui.line(line);
-            let points: PlotPoints = self
-                .train
+            let points: PlotPoints = train
                 .iter_rows()
                 .map(|sample| [sample[0], self.model.predict(sample)[(0, 0)]])
                 .collect();
@@ -425,7 +392,7 @@ impl DeepRenderApp {
                     self.img.paint(
                         &response,
                         &painter,
-                        &self.train,
+                        self.sampler.full(),
                         |train: &Matrix| {
                             let image = (0..angle_stride)
                                 .map(|i| {
@@ -449,7 +416,7 @@ impl DeepRenderApp {
                     self.img_predict.paint(
                         &response,
                         &painter,
-                        (&self.train, &self.model),
+                        (self.sampler.full(), &self.model),
                         |(train, model): (&Matrix, &Model)| {
                             let image = (0..angle_stride * self.upsample * self.upsample)
                                 .map(|i| {
@@ -473,7 +440,7 @@ impl DeepRenderApp {
                     self.img.paint(
                         &response,
                         &painter,
-                        &self.train,
+                        self.sampler.full(),
                         |train: &Matrix| {
                             let image = (0..train.rows())
                                 .map(|i| {
@@ -493,7 +460,7 @@ impl DeepRenderApp {
                     self.img_predict.paint(
                         &response,
                         &painter,
-                        (&self.train, &self.model),
+                        (self.sampler.full(), &self.model),
                         |(train, model): (&Matrix, &Model)| {
                             let image = (0..train.rows())
                                 .map(|i| {
@@ -550,7 +517,7 @@ impl eframe::App for DeepRenderApp {
                 });
         }
 
-        match self.train.cols() {
+        match self.sampler.full().cols() {
             2 => {
                 egui::TopBottomPanel::bottom("func_plot")
                     .resizable(true)

--- a/src/app.rs
+++ b/src/app.rs
@@ -114,7 +114,9 @@ impl DeepRenderApp {
         for _ in 0..self.trains_per_frame {
             let samples = self.sampler.sample(self.train_batch, self.batch_size);
             self.model.learn(rate, &samples);
-            self.loss_history.push(self.model.loss(self.sampler.full()));
+        }
+        self.loss_history.push(self.model.loss(self.sampler.full()));
+        if self.plot_weights {
             self.add_weights_history();
         }
     }
@@ -328,7 +330,7 @@ impl DeepRenderApp {
                 ui.label("Trains per frame:");
                 ui.add(egui::widgets::Slider::new(
                     &mut self.trains_per_frame,
-                    1..=50,
+                    1..=150,
                 ));
             });
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod fit_model;
 mod matrix;
 mod model;
 mod optimizer;
+mod sampler;
 
 use app::DeepRenderApp;
 

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1,0 +1,70 @@
+use rand::seq::SliceRandom;
+
+use crate::matrix::Matrix;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum TrainBatch {
+    Sequence,
+    Shuffle,
+    Full,
+}
+
+pub(crate) trait Sampler {
+    fn sample(&mut self, train_batch: TrainBatch, batch_size: usize) -> Matrix;
+    fn full(&self) -> &Matrix;
+}
+
+pub(crate) struct MatrixSampler {
+    train: Matrix,
+    order: Vec<usize>,
+}
+
+impl Sampler for MatrixSampler {
+    fn sample(&mut self, train_batch: TrainBatch, batch_size: usize) -> Matrix {
+        match train_batch {
+            TrainBatch::Sequence => {
+                if self.order.is_empty() {
+                    let batches = (self.train.rows() + batch_size - 1) / batch_size;
+                    self.order = (0..self.train.rows()).collect();
+                }
+                let samples = batch_size.min(self.order.len());
+                let mut train = Matrix::zeros(samples, self.train.cols());
+                for j in 0..samples {
+                    train
+                        .row_mut(j)
+                        .copy_from_slice(self.train.row(self.order.pop().unwrap()));
+                }
+                train
+            }
+            TrainBatch::Shuffle => {
+                if self.order.is_empty() {
+                    let batches = (self.train.rows() + batch_size - 1) / batch_size;
+                    self.order = (0..self.train.rows()).collect();
+                    self.order.shuffle(&mut rand::thread_rng());
+                }
+                let samples = batch_size.min(self.order.len());
+                let mut train = Matrix::zeros(samples, self.train.cols());
+                for j in 0..samples {
+                    train
+                        .row_mut(j)
+                        .copy_from_slice(self.train.row(self.order.pop().unwrap()));
+                }
+                train
+            }
+            TrainBatch::Full => self.train.clone(),
+        }
+    }
+
+    fn full(&self) -> &Matrix {
+        &self.train
+    }
+}
+
+impl MatrixSampler {
+    pub(crate) fn new(train: Matrix) -> Self {
+        Self {
+            train,
+            order: vec![],
+        }
+    }
+}

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -24,7 +24,6 @@ impl Sampler for MatrixSampler {
         match train_batch {
             TrainBatch::Sequence => {
                 if self.order.is_empty() {
-                    let batches = (self.train.rows() + batch_size - 1) / batch_size;
                     self.order = (0..self.train.rows()).collect();
                 }
                 let samples = batch_size.min(self.order.len());
@@ -38,7 +37,6 @@ impl Sampler for MatrixSampler {
             }
             TrainBatch::Shuffle => {
                 if self.order.is_empty() {
-                    let batches = (self.train.rows() + batch_size - 1) / batch_size;
                     self.order = (0..self.train.rows()).collect();
                     self.order.shuffle(&mut rand::thread_rng());
                 }


### PR DESCRIPTION
# `Sampler` trait

Now we can split the traning data into batches and render the GUI in between each of them, thanks to the sampler trait implemented as state machines.

```rust
pub(crate) trait Sampler {
    fn sample(&mut self, train_batch: TrainBatch, batch_size: usize) -> Matrix;
    fn full(&self) -> &Matrix;
}
```

# `MatrixSampler` struct

The `MatrixSampler` struct which implements this trait has internal state that can make progress every `sample`.
It also provides with `full` method, which is used to evaluate global loss function (which is not necessarily evaluated every batch because evaluating the whole training set's loss can be time consuming).

The effect of this is that the GUI won't freeze for a large training set. Previously, we run the whole training set every frame, but it can be much slower than 16ms and we won't achieve 60fps. Now you can adjust the number of batches to train per frame in the control panel.

![image](https://github.com/msakuta/DeepRender/assets/2798715/50e06251-7f1e-4f23-8026-6952fe7e2b99)


# `MatrixSampler` struct

There is another implementor of `Sampler` which is `RaytraceSampler`. This sampler does not use pre-allocated sample array. It uses truly random rays every time it samples. It can make the scene rendering smoother because it is trained in actually random samples in between pixels and angle units, unlike pre-sampled raster images.

You can see the result:

![DeepRender3DResult6](https://github.com/msakuta/DeepRender/assets/2798715/3840eba1-e3c9-4d59-851f-de0a52b9a11a)

The reference image on the left is not very accurate anymore because the network is not trained on this pixelated image, but putting a large image here is costly in itself (because we need to evaluate the value over the whole 3D image to calculate the loss).
