### PR TITLE
Add NetworkRender mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,7 +1492,7 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 [[package]]
 name = "ray-rust"
 version = "0.1.0"
-source = "git+https://github.com/msakuta/ray-rust.git#093e0a66a187a0d65af25d6e5420f2286775d78a"
+source = "git+https://github.com/msakuta/ray-rust.git#f29aaa5b4cc78e116f25f67d29c8b3652ae1438b"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,11 +1,12 @@
 mod graph;
 mod image;
+mod ui_panel;
 
 use eframe::egui::{
     self,
     plot::{Legend, Line, PlotPoints},
     widgets::plot::Plot,
-    TextEdit, Ui,
+    Ui,
 };
 
 use self::graph::NetworkRender;
@@ -14,7 +15,6 @@ use crate::{
     activation::ActivationFn,
     bg_image::BgImage,
     fit_model::{FitModel, ImageSize, IMAGE_HALFWIDTH},
-    matrix::Matrix,
     model::Model,
     optimizer::OptimizerType,
     sampler::{Sampler, TrainBatch},
@@ -168,139 +168,6 @@ impl DeepRenderApp {
                     .name(format!("weights[{}, {}]", i / 2, i % 2))
             })
             .collect()
-    }
-
-    fn ui_panel(&mut self, ui: &mut Ui) {
-        ui.horizontal(|ui| {
-            if ui.button("Reset").clicked() {
-                self.reset();
-            }
-
-            let paused_label = if self.paused { "Unpause" } else { "Pause" };
-            if ui.button(paused_label).clicked() {
-                self.paused = !self.paused;
-            }
-        });
-
-        ui.group(|ui| {
-            ui.label("Fit model:");
-
-            ui.horizontal(|ui| {
-                ui.radio_value(&mut self.fit_model, FitModel::Xor, "Xor");
-                ui.radio_value(&mut self.fit_model, FitModel::Sine, "Sine");
-                ui.radio_value(&mut self.fit_model, FitModel::SynthImage, "SynthImage");
-                #[cfg(not(target_arch = "wasm32"))]
-                ui.radio_value(&mut self.fit_model, FitModel::FileImage, "FileImage");
-            });
-
-            #[cfg(not(target_arch = "wasm32"))]
-            ui.horizontal(|ui| {
-                ui.label("File name:");
-                ui.add_enabled(
-                    matches!(self.fit_model, FitModel::FileImage),
-                    TextEdit::singleline(&mut self.file_name),
-                );
-            });
-
-            ui.radio_value(
-                &mut self.fit_model,
-                FitModel::RaytraceImage,
-                "RaytraceImage",
-            );
-            ui.radio_value(&mut self.fit_model, FitModel::Raytrace3D, "Raytrace3D");
-
-            ui.horizontal(|ui| {
-                ui.label("Image size:");
-                ui.add_enabled(
-                    matches!(
-                        self.fit_model,
-                        FitModel::RaytraceImage | FitModel::Raytrace3D
-                    ),
-                    egui::widgets::Slider::new(&mut self.synth_image_size, 8..=30),
-                );
-            })
-        });
-
-        ui.horizontal(|ui| {
-            ui.label("Activation fn:");
-            ui.radio_value(&mut self.activation_fn, ActivationFn::Sigmoid, "Sigmoid");
-            ui.radio_value(&mut self.activation_fn, ActivationFn::Relu, "ReLU");
-            ui.radio_value(&mut self.activation_fn, ActivationFn::Silu, "SiLU");
-            ui.radio_value(&mut self.activation_fn, ActivationFn::Sin, "Sin");
-        });
-
-        ui.horizontal(|ui| {
-            ui.label("Optimizer:");
-            ui.radio_value(&mut self.optimizer, OptimizerType::Steepest, "Steepest");
-            ui.radio_value(&mut self.optimizer, OptimizerType::Adam, "Adam");
-        });
-
-        ui.group(|ui| {
-            ui.horizontal(|ui| {
-                ui.label("Train batch: ");
-                ui.radio_value(&mut self.train_batch, TrainBatch::Sequence, "Sequence");
-                ui.radio_value(&mut self.train_batch, TrainBatch::Shuffle, "Shuffle");
-                ui.radio_value(&mut self.train_batch, TrainBatch::Full, "Full");
-            });
-
-            ui.horizontal(|ui| {
-                ui.label("Batch size:");
-                // There is no real point having more than 50 batches.
-                let max_batches = 50;
-                ui.add_enabled(
-                    !matches!(self.train_batch, TrainBatch::Full),
-                    egui::Slider::new(&mut self.batch_size, 1..=max_batches),
-                );
-            })
-        });
-
-        ui.group(|ui| {
-            ui.label("Architecture:");
-
-            ui.horizontal(|ui| {
-                ui.label("Hidden layers:");
-                ui.add(egui::Slider::new(&mut self.hidden_layers, 1..=10));
-            });
-
-            ui.horizontal(|ui| {
-                ui.label("Hidden nodes:");
-                ui.add(egui::Slider::new(&mut self.hidden_nodes, 1..=30));
-            });
-        });
-
-        ui.group(|ui| {
-            ui.horizontal(|ui| {
-                ui.label("Descent rate log10:");
-                ui.add(egui::Slider::new(&mut self.rate, -10.0..=0.));
-            });
-            ui.label(format!("Descent rate: {}", (10.0f64).powf(self.rate)));
-            ui.horizontal(|ui| {
-                ui.label("Trains per frame:");
-                ui.add(egui::widgets::Slider::new(
-                    &mut self.trains_per_frame,
-                    1..=1000,
-                ));
-            });
-        });
-
-        ui.checkbox(&mut self.plot_network, "Plot network");
-
-        ui.checkbox(&mut self.plot_weights, "Plot weights (uncheck for speed)");
-
-        ui.checkbox(&mut self.print_weights, "Print weights (uncheck for speed)");
-
-        ui.label(format!(
-            "Loss: {}",
-            self.loss_history.last().copied().unwrap_or(0.)
-        ));
-
-        if self.print_weights {
-            ui.label(format!("Model:\n{}", self.model));
-            for sample in self.sampler.full().iter_rows() {
-                let predict = self.model.predict(sample);
-                ui.label(format!("{} -> {}", Matrix::new_row(&sample[0..2]), predict));
-            }
-        }
     }
 
     fn func_plot(&self, ui: &mut Ui) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,11 @@
 mod graph;
+mod image;
 
 use eframe::egui::{
     self,
     plot::{Legend, Line, PlotPoints},
     widgets::plot::Plot,
-    Frame, TextEdit, Ui,
+    TextEdit, Ui,
 };
 
 use self::graph::NetworkRender;
@@ -12,7 +13,7 @@ use self::graph::NetworkRender;
 use crate::{
     activation::ActivationFn,
     bg_image::BgImage,
-    fit_model::{FitModel, ImageSize, ANGLES, IMAGE_HALFWIDTH},
+    fit_model::{FitModel, ImageSize, IMAGE_HALFWIDTH},
     matrix::Matrix,
     model::Model,
     optimizer::OptimizerType,
@@ -320,126 +321,6 @@ impl DeepRenderApp {
                 .collect();
             let line_predict = Line::new(points).name("Predicted");
             plot_ui.line(line_predict);
-        });
-    }
-
-    fn image_plot(&mut self, ui: &mut Ui) {
-        ui.horizontal(|ui| {
-            ui.label("Angle:");
-            if ui
-                .add(egui::widgets::Slider::new(
-                    &mut self.angle,
-                    (0.)..=(ANGLES - 1) as f64,
-                ))
-                .changed()
-            {
-                self.img.clear();
-            }
-
-            ui.label("Upsample:");
-            ui.add(egui::widgets::Slider::new(&mut self.upsample, 1..=4));
-        });
-
-        Frame::canvas(ui.style()).show(ui, |ui| {
-            let (response, painter) =
-                ui.allocate_painter(ui.available_size(), egui::Sense::hover());
-
-            let Some(image_size) = self.image_size else {
-                return;
-            };
-
-            match self.current_fit_model {
-                FitModel::Raytrace3D => {
-                    let angle_stride = image_size[0] * image_size[1];
-                    let angle = self.angle as usize;
-                    self.img.paint(
-                        &response,
-                        &painter,
-                        self.sampler.full(),
-                        |train: &Matrix| {
-                            let image = (0..angle_stride)
-                                .map(|i| {
-                                    let b = (train[(angle * angle_stride + i, 3)] * 255.)
-                                        .max(0.)
-                                        .min(255.);
-                                    [b as u8; 3]
-                                })
-                                .flatten()
-                                .collect::<Vec<_>>();
-                            egui::ColorImage::from_rgb(image_size, &image)
-                        },
-                        [25., 25.],
-                        5.,
-                    );
-
-                    let image_upsize =
-                        [image_size[0] * self.upsample, image_size[1] * self.upsample];
-
-                    self.img_predict.clear();
-                    self.img_predict.paint(
-                        &response,
-                        &painter,
-                        &self.model,
-                        |model: &Model| {
-                            let image = (0..angle_stride * self.upsample * self.upsample)
-                                .map(|i| {
-                                    let x =
-                                        (i % image_upsize[0]) as f64 / image_upsize[0] as f64 - 0.5;
-                                    let y =
-                                        (i / image_upsize[0]) as f64 / image_upsize[1] as f64 - 0.5;
-                                    let sample = [x, y, self.angle / ANGLES as f64 - 0.5];
-                                    let predict = model.predict(&sample);
-                                    [(predict[(0, 0)] * 255.).max(0.).min(255.) as u8; 3]
-                                })
-                                .flatten()
-                                .collect::<Vec<_>>();
-                            egui::ColorImage::from_rgb(image_upsize, &image)
-                        },
-                        [image_size[0] as f32 * 5. + 50., 25.],
-                        5. / self.upsample as f32,
-                    );
-                }
-                _ => {
-                    self.img.paint(
-                        &response,
-                        &painter,
-                        self.sampler.full(),
-                        |train: &Matrix| {
-                            let image = (0..train.rows())
-                                .map(|i| {
-                                    [(train.flat()[i * train.cols() + 2] * 255.)
-                                        .max(0.)
-                                        .min(255.) as u8; 3]
-                                })
-                                .flatten()
-                                .collect::<Vec<_>>();
-                            egui::ColorImage::from_rgb(image_size, &image)
-                        },
-                        [25., 25.],
-                        5.,
-                    );
-
-                    self.img_predict.clear();
-                    self.img_predict.paint(
-                        &response,
-                        &painter,
-                        (self.sampler.full(), &self.model),
-                        |(train, model): (&Matrix, &Model)| {
-                            let image = (0..train.rows())
-                                .map(|i| {
-                                    let sample = train.row(i);
-                                    let predict = model.predict(sample);
-                                    [(predict[(0, 0)] * 255.).max(0.).min(255.) as u8; 3]
-                                })
-                                .flatten()
-                                .collect::<Vec<_>>();
-                            egui::ColorImage::from_rgb(image_size, &image)
-                        },
-                        [image_size[0] as f32 * 5. + 50., 25.],
-                        5.,
-                    );
-                }
-            }
         });
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,12 +1,13 @@
-use eframe::{
-    egui::{
-        self,
-        plot::{Legend, Line, PlotPoints},
-        widgets::plot::Plot,
-        Frame, TextEdit, Ui,
-    },
-    epaint::{pos2, Color32, Pos2, Rect},
+mod graph;
+
+use eframe::egui::{
+    self,
+    plot::{Legend, Line, PlotPoints},
+    widgets::plot::Plot,
+    Frame, TextEdit, Ui,
 };
+
+use self::graph::NetworkRender;
 
 use crate::{
     activation::ActivationFn,
@@ -17,12 +18,6 @@ use crate::{
     optimizer::OptimizerType,
     sampler::{Sampler, TrainBatch},
 };
-
-#[derive(PartialEq, Eq, Debug)]
-enum NetworkRender {
-    Lines,
-    Image,
-}
 
 pub struct DeepRenderApp {
     fit_model: FitModel,
@@ -172,106 +167,6 @@ impl DeepRenderApp {
                     .name(format!("weights[{}, {}]", i / 2, i % 2))
             })
             .collect()
-    }
-
-    fn paint_graph(&mut self, ui: &mut Ui) {
-        ui.horizontal(|ui| {
-            ui.label("Upsample:");
-            ui.radio_value(&mut self.network_render, NetworkRender::Lines, "Lines");
-            ui.radio_value(&mut self.network_render, NetworkRender::Image, "Image");
-        });
-
-        const NODE_OFFSET: f32 = 30.;
-        const NODE_RADIUS: f32 = 7.;
-        const NODE_INTERVAL: f32 = NODE_RADIUS * 3.;
-        const LAYER_INTERVAL: f32 = 70.;
-        const PIXEL_SIZE: f32 = 5.;
-        const IMAGE_OFFSET: f32 = 10. + NODE_RADIUS;
-
-        Frame::canvas(ui.style()).show(ui, |ui| {
-            let (response, painter) =
-                ui.allocate_painter(ui.available_size(), egui::Sense::hover());
-
-            let to_screen = egui::emath::RectTransform::from_to(
-                Rect::from_min_size(Pos2::ZERO, response.rect.size()),
-                response.rect,
-            );
-
-            let to_rgb = |weight: f64| {
-                if weight < 0. {
-                    [(weight.abs() * 255.).min(255.).max(0.) as u8, 0, 0]
-                } else {
-                    [0, (weight * 255.).min(255.).max(0.) as u8, 0]
-                }
-            };
-
-            let to_color = |weight: f64| {
-                let rgb = to_rgb(weight);
-                Color32::from_rgb(rgb[0], rgb[1], rgb[2])
-            };
-
-            let mut x = NODE_OFFSET;
-            let mut x_offsets = Vec::with_capacity(self.model.get_weights().len());
-
-            for (n, weights) in self.model.get_weights().iter().enumerate() {
-                x_offsets.push(x);
-                match self.network_render {
-                    NetworkRender::Lines => {
-                        for i in 0..weights.rows() {
-                            // let rect = Rect{ min: pos2(30., 30. + i as f32 * 30.), max: pos2(80., 50. + i as f32 * 30.) };
-                            let soure = pos2(x, NODE_OFFSET + i as f32 * NODE_INTERVAL);
-                            for j in 0..self.model.get_arch()[n + 1] {
-                                let dest = pos2(
-                                    x + LAYER_INTERVAL,
-                                    NODE_OFFSET + j as f32 * NODE_INTERVAL,
-                                );
-                                painter.line_segment(
-                                    [
-                                        to_screen.transform_pos(soure),
-                                        to_screen.transform_pos(dest),
-                                    ],
-                                    (1., to_color(weights[(i, j)])),
-                                );
-                            }
-                        }
-                        x += LAYER_INTERVAL;
-                    }
-                    NetworkRender::Image => {
-                        let mut img = BgImage::new();
-                        img.paint(
-                            &response,
-                            &painter,
-                            weights,
-                            |weights: &Matrix| {
-                                let image = weights
-                                    .flat()
-                                    .iter()
-                                    .copied()
-                                    .map(to_rgb)
-                                    .flatten()
-                                    .collect::<Vec<_>>();
-                                egui::ColorImage::from_rgb([weights.cols(), weights.rows()], &image)
-                            },
-                            [x + IMAGE_OFFSET, 25.],
-                            PIXEL_SIZE,
-                        );
-                        x += weights.cols() as f32 * PIXEL_SIZE + IMAGE_OFFSET * 2.;
-                    }
-                }
-            }
-
-            for (weights, x) in self.model.get_weights().iter().zip(x_offsets.into_iter()) {
-                for i in 0..weights.rows() {
-                    let center = pos2(x, NODE_OFFSET + i as f32 * NODE_INTERVAL);
-                    painter.circle(
-                        to_screen.transform_pos(center),
-                        NODE_RADIUS,
-                        to_color(weights[(i, 0)]),
-                        (1., Color32::GRAY),
-                    );
-                }
-            }
-        });
     }
 
     fn ui_panel(&mut self, ui: &mut Ui) {

--- a/src/app/graph.rs
+++ b/src/app/graph.rs
@@ -1,0 +1,116 @@
+use crate::{bg_image::BgImage, matrix::Matrix};
+
+use super::DeepRenderApp;
+
+use eframe::{
+    egui::{self, Frame, Ui},
+    epaint::{pos2, Color32, Pos2, Rect},
+};
+
+#[derive(PartialEq, Eq, Debug)]
+pub(super) enum NetworkRender {
+    Lines,
+    Image,
+}
+
+impl DeepRenderApp {
+    pub(super) fn paint_graph(&mut self, ui: &mut Ui) {
+        ui.horizontal(|ui| {
+            ui.label("Upsample:");
+            ui.radio_value(&mut self.network_render, NetworkRender::Lines, "Lines");
+            ui.radio_value(&mut self.network_render, NetworkRender::Image, "Image");
+        });
+
+        const NODE_OFFSET: f32 = 30.;
+        const NODE_RADIUS: f32 = 7.;
+        const NODE_INTERVAL: f32 = NODE_RADIUS * 3.;
+        const LAYER_INTERVAL: f32 = 70.;
+        const PIXEL_SIZE: f32 = 5.;
+        const IMAGE_OFFSET: f32 = 10. + NODE_RADIUS;
+
+        Frame::canvas(ui.style()).show(ui, |ui| {
+            let (response, painter) =
+                ui.allocate_painter(ui.available_size(), egui::Sense::hover());
+
+            let to_screen = egui::emath::RectTransform::from_to(
+                Rect::from_min_size(Pos2::ZERO, response.rect.size()),
+                response.rect,
+            );
+
+            let to_rgb = |weight: f64| {
+                if weight < 0. {
+                    [(weight.abs() * 255.).min(255.).max(0.) as u8, 0, 0]
+                } else {
+                    [0, (weight * 255.).min(255.).max(0.) as u8, 0]
+                }
+            };
+
+            let to_color = |weight: f64| {
+                let rgb = to_rgb(weight);
+                Color32::from_rgb(rgb[0], rgb[1], rgb[2])
+            };
+
+            let mut x = NODE_OFFSET;
+            let mut x_offsets = Vec::with_capacity(self.model.get_weights().len());
+
+            for (n, weights) in self.model.get_weights().iter().enumerate() {
+                x_offsets.push(x);
+                match self.network_render {
+                    NetworkRender::Lines => {
+                        for i in 0..weights.rows() {
+                            // let rect = Rect{ min: pos2(30., 30. + i as f32 * 30.), max: pos2(80., 50. + i as f32 * 30.) };
+                            let soure = pos2(x, NODE_OFFSET + i as f32 * NODE_INTERVAL);
+                            for j in 0..self.model.get_arch()[n + 1] {
+                                let dest = pos2(
+                                    x + LAYER_INTERVAL,
+                                    NODE_OFFSET + j as f32 * NODE_INTERVAL,
+                                );
+                                painter.line_segment(
+                                    [
+                                        to_screen.transform_pos(soure),
+                                        to_screen.transform_pos(dest),
+                                    ],
+                                    (1., to_color(weights[(i, j)])),
+                                );
+                            }
+                        }
+                        x += LAYER_INTERVAL;
+                    }
+                    NetworkRender::Image => {
+                        let mut img = BgImage::new();
+                        img.paint(
+                            &response,
+                            &painter,
+                            weights,
+                            |weights: &Matrix| {
+                                let image = weights
+                                    .flat()
+                                    .iter()
+                                    .copied()
+                                    .map(to_rgb)
+                                    .flatten()
+                                    .collect::<Vec<_>>();
+                                egui::ColorImage::from_rgb([weights.cols(), weights.rows()], &image)
+                            },
+                            [x + IMAGE_OFFSET, 25.],
+                            PIXEL_SIZE,
+                        );
+                        x += weights.cols() as f32 * PIXEL_SIZE + IMAGE_OFFSET * 2.;
+                    }
+                }
+            }
+
+            for (weights, x) in self.model.get_weights().iter().zip(x_offsets.into_iter()) {
+                for i in 0..weights.rows() {
+                    let center = pos2(x, NODE_OFFSET + i as f32 * NODE_INTERVAL);
+                    painter.circle(
+                        to_screen.transform_pos(center),
+                        NODE_RADIUS,
+                        to_color(weights[(i, 0)]),
+                        (1., Color32::GRAY),
+                    );
+                }
+            }
+        });
+    }
+}

--- a/src/app/image.rs
+++ b/src/app/image.rs
@@ -1,0 +1,131 @@
+use crate::{
+    fit_model::{FitModel, ANGLES},
+    matrix::Matrix,
+    model::Model,
+};
+
+use super::DeepRenderApp;
+
+use eframe::egui::{self, Frame, Ui};
+
+impl DeepRenderApp {
+    pub(super) fn image_plot(&mut self, ui: &mut Ui) {
+        ui.horizontal(|ui| {
+            ui.label("Angle:");
+            if ui
+                .add(egui::widgets::Slider::new(
+                    &mut self.angle,
+                    (0.)..=(ANGLES - 1) as f64,
+                ))
+                .changed()
+            {
+                self.img.clear();
+            }
+
+            ui.label("Upsample:");
+            ui.add(egui::widgets::Slider::new(&mut self.upsample, 1..=4));
+        });
+
+        Frame::canvas(ui.style()).show(ui, |ui| {
+            let (response, painter) =
+                ui.allocate_painter(ui.available_size(), egui::Sense::hover());
+
+            let Some(image_size) = self.image_size else {
+            return;
+        };
+
+            match self.current_fit_model {
+                FitModel::Raytrace3D => {
+                    let angle_stride = image_size[0] * image_size[1];
+                    let angle = self.angle as usize;
+                    self.img.paint(
+                        &response,
+                        &painter,
+                        self.sampler.full(),
+                        |train: &Matrix| {
+                            let image = (0..angle_stride)
+                                .map(|i| {
+                                    let b = (train[(angle * angle_stride + i, 3)] * 255.)
+                                        .max(0.)
+                                        .min(255.);
+                                    [b as u8; 3]
+                                })
+                                .flatten()
+                                .collect::<Vec<_>>();
+                            egui::ColorImage::from_rgb(image_size, &image)
+                        },
+                        [25., 25.],
+                        5.,
+                    );
+
+                    let image_upsize =
+                        [image_size[0] * self.upsample, image_size[1] * self.upsample];
+
+                    self.img_predict.clear();
+                    self.img_predict.paint(
+                        &response,
+                        &painter,
+                        &self.model,
+                        |model: &Model| {
+                            let image = (0..angle_stride * self.upsample * self.upsample)
+                                .map(|i| {
+                                    let x =
+                                        (i % image_upsize[0]) as f64 / image_upsize[0] as f64 - 0.5;
+                                    let y =
+                                        (i / image_upsize[0]) as f64 / image_upsize[1] as f64 - 0.5;
+                                    let sample = [x, y, self.angle / ANGLES as f64 - 0.5];
+                                    let predict = model.predict(&sample);
+                                    [(predict[(0, 0)] * 255.).max(0.).min(255.) as u8; 3]
+                                })
+                                .flatten()
+                                .collect::<Vec<_>>();
+                            egui::ColorImage::from_rgb(image_upsize, &image)
+                        },
+                        [image_size[0] as f32 * 5. + 50., 25.],
+                        5. / self.upsample as f32,
+                    );
+                }
+                _ => {
+                    self.img.paint(
+                        &response,
+                        &painter,
+                        self.sampler.full(),
+                        |train: &Matrix| {
+                            let image = (0..train.rows())
+                                .map(|i| {
+                                    [(train.flat()[i * train.cols() + 2] * 255.)
+                                        .max(0.)
+                                        .min(255.) as u8; 3]
+                                })
+                                .flatten()
+                                .collect::<Vec<_>>();
+                            egui::ColorImage::from_rgb(image_size, &image)
+                        },
+                        [25., 25.],
+                        5.,
+                    );
+
+                    self.img_predict.clear();
+                    self.img_predict.paint(
+                        &response,
+                        &painter,
+                        (self.sampler.full(), &self.model),
+                        |(train, model): (&Matrix, &Model)| {
+                            let image = (0..train.rows())
+                                .map(|i| {
+                                    let sample = train.row(i);
+                                    let predict = model.predict(sample);
+                                    [(predict[(0, 0)] * 255.).max(0.).min(255.) as u8; 3]
+                                })
+                                .flatten()
+                                .collect::<Vec<_>>();
+                            egui::ColorImage::from_rgb(image_size, &image)
+                        },
+                        [image_size[0] as f32 * 5. + 50., 25.],
+                        5.,
+                    );
+                }
+            }
+        });
+    }
+}

--- a/src/app/ui_panel.rs
+++ b/src/app/ui_panel.rs
@@ -1,0 +1,143 @@
+use eframe::egui::{self, TextEdit, Ui};
+
+use super::DeepRenderApp;
+
+use crate::{
+    activation::ActivationFn, fit_model::FitModel, matrix::Matrix, optimizer::OptimizerType,
+    sampler::TrainBatch,
+};
+
+impl DeepRenderApp {
+    pub(super) fn ui_panel(&mut self, ui: &mut Ui) {
+        ui.horizontal(|ui| {
+            if ui.button("Reset").clicked() {
+                self.reset();
+            }
+
+            let paused_label = if self.paused { "Unpause" } else { "Pause" };
+            if ui.button(paused_label).clicked() {
+                self.paused = !self.paused;
+            }
+        });
+
+        ui.group(|ui| {
+            ui.label("Fit model:");
+
+            ui.horizontal(|ui| {
+                ui.radio_value(&mut self.fit_model, FitModel::Xor, "Xor");
+                ui.radio_value(&mut self.fit_model, FitModel::Sine, "Sine");
+                ui.radio_value(&mut self.fit_model, FitModel::SynthImage, "SynthImage");
+                #[cfg(not(target_arch = "wasm32"))]
+                ui.radio_value(&mut self.fit_model, FitModel::FileImage, "FileImage");
+            });
+
+            #[cfg(not(target_arch = "wasm32"))]
+            ui.horizontal(|ui| {
+                ui.label("File name:");
+                ui.add_enabled(
+                    matches!(self.fit_model, FitModel::FileImage),
+                    TextEdit::singleline(&mut self.file_name),
+                );
+            });
+
+            ui.radio_value(
+                &mut self.fit_model,
+                FitModel::RaytraceImage,
+                "RaytraceImage",
+            );
+            ui.radio_value(&mut self.fit_model, FitModel::Raytrace3D, "Raytrace3D");
+
+            ui.horizontal(|ui| {
+                ui.label("Image size:");
+                ui.add_enabled(
+                    matches!(
+                        self.fit_model,
+                        FitModel::RaytraceImage | FitModel::Raytrace3D
+                    ),
+                    egui::widgets::Slider::new(&mut self.synth_image_size, 8..=30),
+                );
+            })
+        });
+
+        ui.horizontal(|ui| {
+            ui.label("Activation fn:");
+            ui.radio_value(&mut self.activation_fn, ActivationFn::Sigmoid, "Sigmoid");
+            ui.radio_value(&mut self.activation_fn, ActivationFn::Relu, "ReLU");
+            ui.radio_value(&mut self.activation_fn, ActivationFn::Silu, "SiLU");
+            ui.radio_value(&mut self.activation_fn, ActivationFn::Sin, "Sin");
+        });
+
+        ui.horizontal(|ui| {
+            ui.label("Optimizer:");
+            ui.radio_value(&mut self.optimizer, OptimizerType::Steepest, "Steepest");
+            ui.radio_value(&mut self.optimizer, OptimizerType::Adam, "Adam");
+        });
+
+        ui.group(|ui| {
+            ui.horizontal(|ui| {
+                ui.label("Train batch: ");
+                ui.radio_value(&mut self.train_batch, TrainBatch::Sequence, "Sequence");
+                ui.radio_value(&mut self.train_batch, TrainBatch::Shuffle, "Shuffle");
+                ui.radio_value(&mut self.train_batch, TrainBatch::Full, "Full");
+            });
+
+            ui.horizontal(|ui| {
+                ui.label("Batch size:");
+                // There is no real point having more than 50 batches.
+                let max_batches = 50;
+                ui.add_enabled(
+                    !matches!(self.train_batch, TrainBatch::Full),
+                    egui::Slider::new(&mut self.batch_size, 1..=max_batches),
+                );
+            })
+        });
+
+        ui.group(|ui| {
+            ui.label("Architecture:");
+
+            ui.horizontal(|ui| {
+                ui.label("Hidden layers:");
+                ui.add(egui::Slider::new(&mut self.hidden_layers, 1..=10));
+            });
+
+            ui.horizontal(|ui| {
+                ui.label("Hidden nodes:");
+                ui.add(egui::Slider::new(&mut self.hidden_nodes, 1..=30));
+            });
+        });
+
+        ui.group(|ui| {
+            ui.horizontal(|ui| {
+                ui.label("Descent rate log10:");
+                ui.add(egui::Slider::new(&mut self.rate, -10.0..=0.));
+            });
+            ui.label(format!("Descent rate: {}", (10.0f64).powf(self.rate)));
+            ui.horizontal(|ui| {
+                ui.label("Trains per frame:");
+                ui.add(egui::widgets::Slider::new(
+                    &mut self.trains_per_frame,
+                    1..=1000,
+                ));
+            });
+        });
+
+        ui.checkbox(&mut self.plot_network, "Plot network");
+
+        ui.checkbox(&mut self.plot_weights, "Plot weights (uncheck for speed)");
+
+        ui.checkbox(&mut self.print_weights, "Print weights (uncheck for speed)");
+
+        ui.label(format!(
+            "Loss: {}",
+            self.loss_history.last().copied().unwrap_or(0.)
+        ));
+
+        if self.print_weights {
+            ui.label(format!("Model:\n{}", self.model));
+            for sample in self.sampler.full().iter_rows() {
+                let predict = self.model.predict(sample);
+                ui.label(format!("{} -> {}", Matrix::new_row(&sample[0..2]), predict));
+            }
+        }
+    }
+}


### PR DESCRIPTION
The new mode NetworkRender::Image will visualize the weights as images rather than lines. It is easier to see in large networks.

![image](https://github.com/msakuta/DeepRender/assets/2798715/9d482b3b-53e4-42cf-8cb7-caad1c341afa)

![image](https://github.com/msakuta/DeepRender/assets/2798715/cf433cc1-5121-429b-96f0-b1b264938865)

![image](https://github.com/msakuta/DeepRender/assets/2798715/5b5716a4-80f2-4a02-b1d4-d18694a0ba38)


Also fixed a bug that weight connection lines had wrong color. Correctly it should look like this:

![image](https://github.com/msakuta/DeepRender/assets/2798715/7afb704f-3df8-4437-91bd-958888a012a9)

Also refactored app.rs to split into submodules since it was getting large.
